### PR TITLE
Catch all exceptions in SystemInfo

### DIFF
--- a/Source/ActivityRunner/Viewer3D/Viewer.cs
+++ b/Source/ActivityRunner/Viewer3D/Viewer.cs
@@ -696,13 +696,10 @@ namespace Orts.ActivityRunner.Viewer3D
                     if (((string)videoController["Description"] == adapterDescription) && (videoController["AdapterRAM"] != null))
                         adapterMemory = (uint)videoController["AdapterRAM"];
             }
-            catch (ManagementException error)
+            catch (Exception error)
             {
                 Trace.WriteLine(error);
-            }
-            catch (UnauthorizedAccessException error)
-            {
-                Trace.WriteLine(error);
+                adapterMemory = 0;
             }
         }
 

--- a/Source/Orts.Common/Info/SystemInfo.cs
+++ b/Source/Orts.Common/Info/SystemInfo.cs
@@ -63,7 +63,7 @@ namespace Orts.Common.Info
                     }
                 }
             }
-            catch (ManagementException error)
+            catch (Exception error)
             {
                 Trace.WriteLine(error);
             }
@@ -77,7 +77,7 @@ namespace Orts.Common.Info
                     }
                 }
             }
-            catch (ManagementException error)
+            catch (Exception error)
             {
                 Trace.WriteLine(error);
             }
@@ -92,10 +92,10 @@ namespace Orts.Common.Info
                     }
                 }
             }
-            catch (ManagementException error)
+            catch (Exception error)
             {
                 Trace.WriteLine(error);
-            }
+            } 
 
             foreach (Screen screen in Screen.AllScreens)
             {
@@ -112,7 +112,7 @@ namespace Orts.Common.Info
                     }
                 }
             }
-            catch (ManagementException error)
+            catch (Exception error)
             {
                 Trace.WriteLine(error);
             }
@@ -129,7 +129,7 @@ namespace Orts.Common.Info
                     }
                 }
             }
-            catch (ManagementException error)
+            catch (Exception error)
             {
                 Trace.WriteLine(error);
             }
@@ -143,7 +143,7 @@ namespace Orts.Common.Info
                     }
                 }
             }
-            catch (ManagementException error)
+            catch (Exception error)
             {
                 Trace.WriteLine(error);
             }


### PR DESCRIPTION
Logging  of system information isn't a critical process, we can just catch all the exceptions and log them. 